### PR TITLE
Create subheading component with Fontawesome caret icon

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -92,18 +92,3 @@ export default {
   },
 };
 </script>
-
-<style>
-/** TODO: A different method, likely a v-on:click method, to update the arrow icons */
-.summary:before {
-  font-family: 'Font Awesome\ 5 Free';
-  float: left;
-  content: '\f150\00a0\00a0';
-}
-
-.summary.collapsed:before {
-  font-family: 'Font Awesome\ 5 Free';
-  float: left;
-  content: '\f152\00a0\00a0';
-}
-</style>

--- a/src/components/CollapseSubheading.vue
+++ b/src/components/CollapseSubheading.vue
@@ -1,0 +1,35 @@
+<template>
+  <a
+    class="subheading mb-3 summary"
+    :href="target"
+    data-bs-toggle="collapse"
+    :data-bs-target="target"
+    style="text-decoration: none"
+    @click="() => (active = !active)"
+  >
+    <font-awesome-icon v-if="!active" :icon="['far', 'square-caret-right']" />
+    <font-awesome-icon v-if="active" :icon="['far', 'square-caret-down']" />
+    {{ headingText }}
+  </a>
+</template>
+
+<script lang="ts">
+export default {
+  name: 'CollapseSubheading',
+  props: {
+    headingText: {
+      type: String,
+      default: '',
+    },
+    target: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      active: false,
+    };
+  },
+};
+</script>

--- a/src/components/Education.vue
+++ b/src/components/Education.vue
@@ -5,14 +5,10 @@
       <div :class="classes.item">
         <div class="resume-content">
           <h3 class="mb-0">BS: Computer Science (Minor Sociology)</h3>
-          <a
-            class="subheading mb-3 summary"
-            href="#compSci"
-            data-bs-toggle="collapse"
-            style="text-decoration: none"
-          >
-            Carleton University
-          </a>
+          <CollapseSubheading
+            heading-text="Carleton University"
+            target="#compSci"
+          />
           <div id="compSci" class="collapse">
             <table class="table">
               <thead>
@@ -57,14 +53,10 @@
       <div :class="classes.item">
         <div class="resume-content">
           <h3 class="mb-0">BS: Integrated Science and Technology</h3>
-          <a
-            class="subheading mb-3 summary"
-            href="#sci"
-            data-bs-toggle="collapse"
-            style="text-decoration: none"
-          >
-            Carleton University
-          </a>
+          <CollapseSubheading
+            heading-text="Carleton University"
+            target="#sci"
+          />
           <div id="sci" class="collapse">
             <table class="table dont-print">
               <thead>

--- a/src/components/Experience.vue
+++ b/src/components/Experience.vue
@@ -9,14 +9,10 @@
       >
         <div class="resume-content">
           <h3 class="mb-0">{{ experience.position }}</h3>
-          <a
-            class="subheading mb-3 summary"
-            style="text-decoration: none; cursor: pointer"
-            data-bs-toggle="collapse"
-            :data-bs-target="'#' + experience.id"
-          >
-            {{ experience.company }}
-          </a>
+          <CollapseSubheading
+            :heading-text="experience.company"
+            :target="'#' + experience.id"
+          />
           <component
             :is="experience.SUMMARY"
             :id="experience.id"

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -9,10 +9,7 @@
           :key="index"
           class="d-flex align-items-center"
         >
-          <font-awesome-icon
-            :icon="['fas', 'check']"
-            class="fa-li"
-          ></font-awesome-icon>
+          <font-awesome-icon :icon="['fas', 'check']" class="fa-li" />
           {{ workflow }}
         </li>
       </ul>
@@ -33,7 +30,7 @@
             v-else-if="tools.icon"
             v-tooltip="tools.name"
             :icon="[tools.library, tools.icon]"
-          ></font-awesome-icon>
+          />
         </li>
       </ul>
     </div>

--- a/src/components/lifeGoals.vue
+++ b/src/components/lifeGoals.vue
@@ -3,27 +3,16 @@
     <div class="w-100">
       <h2 class="pb-5">Life Goals</h2>
       <div>
-        <a
-          class="subheading pb-3 summary"
-          href="#highPriority"
-          data-bs-toggle="collapse"
-          style="text-decoration: none"
-        >
-          High Priority
-        </a>
+        <CollapseSubheading
+          heading-text="High Priority"
+          target="#highPriority"
+        />
         <div id="highPriority" class="collapse ps-5">
           • A new career employment opportunity.
         </div>
       </div>
       <div>
-        <a
-          class="subheading pb-3 summary"
-          href="#shortTerm"
-          data-bs-toggle="collapse"
-          style="text-decoration: none"
-        >
-          This year
-        </a>
+        <CollapseSubheading heading-text="This year" target="#shortTerm" />
         <div id="shortTerm" class="collapse ps-5">
           • G Drivers License: <br />
           <span class="lf"
@@ -52,14 +41,10 @@
         </div>
       </div>
       <div>
-        <a
-          class="subheading pb-3 summary"
-          href="#mediumTerm"
-          data-bs-toggle="collapse"
-          style="text-decoration: none"
-        >
-          Within one to three years
-        </a>
+        <CollapseSubheading
+          heading-text="One to three years"
+          target="#mediumTerm"
+        />
         <div id="mediumTerm" class="collapse ps-5">
           • Pay-off Credit Card: <br />
           <span class="lf"
@@ -90,27 +75,16 @@
         </div>
       </div>
       <div>
-        <a
-          class="subheading pb-3 summary"
-          href="#longTerm"
-          data-bs-toggle="collapse"
-          style="text-decoration: none"
-        >
-          Within seven years
-        </a>
+        <CollapseSubheading
+          heading-text="Within seven years"
+          target="#longTerm"
+        />
         <div id="longTerm" class="collapse ps-5">
           • Pay off student loan: Currently at ~$48K.<br />
         </div>
       </div>
       <div>
-        <a
-          class="subheading pb-3 summary"
-          href="#longerTerm"
-          data-bs-toggle="collapse"
-          style="text-decoration: none"
-        >
-          Longer-Term
-        </a>
+        <CollapseSubheading heading-text="Longer-term" target="#longerTerm" />
         <div id="longerTerm" class="collapse ps-5">
           • Invest: <br />
           <span class="lf"

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,9 +8,12 @@ import 'bootstrap';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { fab } from '@fortawesome/free-brands-svg-icons';
 import { fas } from '@fortawesome/free-solid-svg-icons';
+import { far } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { dom } from '@fortawesome/fontawesome-svg-core';
 import VideoBackground from 'vue-responsive-video-background-player';
+
+import CollapseSubheading from './components/CollapseSubheading.vue';
 
 import {
   // Directives
@@ -23,7 +26,7 @@ import {
 } from 'floating-vue';
 dom.watch();
 
-library.add(fab, fas);
+library.add(fab, fas, far);
 
 // Main SCSS File
 import './assets/scss/resume.scss';
@@ -32,6 +35,7 @@ import 'floating-vue/dist/style.css';
 createApp(App)
   .directive('tooltip', VTooltip)
   .directive('close-popper', VClosePopper)
+  .component('CollapseSubheading', CollapseSubheading)
   .component('VDropdown', Dropdown)
   .component('VTooltip', Tooltip)
   .component('VMenu', Menu)


### PR DESCRIPTION
FontAwesome Caret was implemented using an external `<link>` and then css 'content' specifier. 
This was not reliable and had many drawbacks.
Importing the Fontawesome Free Regular SVG icons package and, creating a custom component both looks cleaner and, works more reliably. 