### PR TITLE
Check linting before build and prevent unwanted console statements

### DIFF
--- a/.eslintrc.prod.json
+++ b/.eslintrc.prod.json
@@ -1,0 +1,21 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "plugin:vue/vue3-recommended",
+    "@vue/typescript/recommended",
+    "prettier"
+  ],
+  "overrides": [],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["vue", "prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "no-console": 2
+  }
+}

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,8 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Create `CollapseSubheading` custom component that uses the
-`Fontawesome Free Regular` SVG icons package. This fixes the arrow's initial
-state and on first click does not work properly.
+  `Fontawesome Free Regular` SVG icons package. This fixes the arrow's initial
+  state and on first click does not work properly.
 
 ## [2.1.0] - 2023/02/25
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Sheldon Maschmeyer <sheldon@maschmeyer.ca>",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "yarn lint -c .eslintrc.prod.json && vite build",
     "preview": "vite preview",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
     "format": "prettier .  --write --ignore-path .gitignore dist node_modules"


### PR DESCRIPTION
`yarn build` command now checks for linting errors before building including the presence of unwanted console statements such as `console.log` and `console.debug`.

In a previous project, multiple developers were working till midnight to meet a hard deadline. A different developer, junior, left a console.debug statement in the code he merged into main, by mistake. The code was deployed in the morning without being throughly checked by senior developers. The client was very unhappy. Beyond being a bad idea to deploy code after a midnight sprint; errors should be prevented whenever possible.

The `no-console` check will detect all console statements that are not wrapped in an ignore statement, showing pre-meditated intent.